### PR TITLE
Trigger "input" event upon insertion of text

### DIFF
--- a/src/autoreviewcomments.user.js
+++ b/src/autoreviewcomments.user.js
@@ -919,7 +919,7 @@ with_jquery(function($) {
       popup.find(".popup-submit").click(function() {
         var selected = popup.find("input:radio:checked");
         var markdown = htmlToMarkDown(selected.parent().find(".action-desc").html()).replace(/\[username\]/g, username).replace(/\[OP\]/g, OP);
-        targetObject.val(markdown).focus(); //focus provokes character count test
+        targetObject.val(markdown).trigger('input').focus(); //focus provokes character count test
         var caret = markdown.indexOf("[type here]");
         if (caret >= 0) targetObject[0].setSelectionRange(caret, caret + "[type here]".length);
         popup.fadeOutAndRemove();


### PR DESCRIPTION
Changing the .val() property programmatically does not trigger either the "input" or "change"
events (see references below). Both of these require actual user engagement. Normally, that
behavior may make sense, but I have a userscript that hooks into this event to automatically
resize the textarea control to accommodate its entire contents. This script is not compatible
with AutoReviewComments unless AutoReviewComments triggers one of these events.

Therefore, this change triggers an "input" event whenever the Markdown is added to the
targetObject (i.e., the textarea).

References:
 - https://stackoverflow.com/questions/37686861/input-event-not-working-if-value-is-changed-with-jquery-val-or-javascript
 - https://stackoverflow.com/questions/2247386/jquery-textbox-valxxxx-not-causing-change-to-fire
 - https://stackoverflow.com/questions/3179385/val-doesnt-trigger-change-in-jquery